### PR TITLE
Error checking for iOS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,25 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 const { NavigationBarColor } = NativeModules;
 
 const changeNavigationBarColor = (color = String, light = false) => {
-  const LightNav = light ? true : false;
-  NavigationBarColor.changeNavigationBarColor(color, LightNav);
+  if(Platform.OS === 'android') {
+    const LightNav = light ? true : false;
+    NavigationBarColor.changeNavigationBarColor(color, LightNav);
+  }
 };
-const HideNavigationBar = () => NavigationBarColor.HideNavigationBar();
-const ShowNavigationBar = () => NavigationBarColor.ShowNavigationBar();
-
+const HideNavigationBar = () => {
+  if(Platform.OS === 'android') {
+    return NavigationBarColor.HideNavigationBar();
+  } else {
+    return false;
+  }
+};
+const ShowNavigationBar = () => {
+  if(Platform.OS === 'android') {
+    NavigationBarColor.ShowNavigationBar();
+  } else {
+    return false;
+  }
+};
 export { changeNavigationBarColor, HideNavigationBar, ShowNavigationBar };


### PR DESCRIPTION
Current implementation allows for an error to occur in iOS builds that implement this module.
Doing a platform check before invoking an Android-specific method allows for iOS to run properly.

Tested and confirmed working on both iOS and Android builds.

We can now implement this without worrying about iOS run-time issues.