### PR TITLE
Add Default Export to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,4 +4,5 @@ declare module "react-native-navigation-bar-color" {
     function ShowNavigationBar(): boolean;
 
     export { changeNavigationBarColor, HideNavigationBar, ShowNavigationBar };
+    export default changeNavigationBarColor;
 }


### PR DESCRIPTION
Update the type definitions file as the default export is missing.
According to the documentation (README) the changeNavigationBarColor
should be a default export and it works but typescript will complain as no
default export is defined in the definitions file