### PR TITLE
Support multiple color format

### DIFF
--- a/android/src/main/java/com/thebylito/navigationbarcolor/NavigationBarColorModule.java
+++ b/android/src/main/java/com/thebylito/navigationbarcolor/NavigationBarColorModule.java
@@ -69,13 +69,13 @@ public class NavigationBarColorModule extends ReactContextBaseJavaModule {
         // Export any constants to be used in your native module
         // https://facebook.github.io/react-native/docs/native-modules-android.html#the-toast-module
         final Map<String, Object> constants = new HashMap<>();
-        constants.put("EXAMPLE_CONSTANT", "example");
+        // constants.put("EXAMPLE_CONSTANT", "example");
 
         return constants;
     }
 
     @ReactMethod
-    public void changeNavigationBarColor(final String color, final Boolean light, final Boolean animated, final Promise promise) {
+    public void changeNavigationBarColor(final Integer color, final Boolean light, final Boolean animated, final Promise promise) {
         final WritableMap map = Arguments.createMap();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             if (getCurrentActivity() != null) {
@@ -84,10 +84,11 @@ public class NavigationBarColorModule extends ReactContextBaseJavaModule {
                     runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
-                            if (color.equals("transparent") || color.equals("translucent")) {
+                            // processColor "translucent" => null
+                            if (color.equals(0) || color==null) {
                                 window.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
                                 window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
-                                if (color.equals("transparent")) {
+                                if (color!=null) {
                                     window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS);
                                 } else {
                                     window.setFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION, WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
@@ -102,9 +103,7 @@ public class NavigationBarColorModule extends ReactContextBaseJavaModule {
                             }
                             if (animated) {
                                 Integer colorFrom = window.getNavigationBarColor();
-                                Integer colorTo = Color.parseColor(String.valueOf(color));
-                                //window.setNavigationBarColor(colorTo);
-                                ValueAnimator colorAnimation = ValueAnimator.ofObject(new ArgbEvaluator(), colorFrom, colorTo);
+                                ValueAnimator colorAnimation = ValueAnimator.ofObject(new ArgbEvaluator(), colorFrom, color.intValue());
                                 colorAnimation.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
                                     @Override
                                     public void onAnimationUpdate(ValueAnimator animator) {
@@ -113,7 +112,7 @@ public class NavigationBarColorModule extends ReactContextBaseJavaModule {
                                 });
                                 colorAnimation.start();
                             } else {
-                                window.setNavigationBarColor(Color.parseColor(String.valueOf(color)));
+                                window.setNavigationBarColor(color.intValue());
                             }
                             setNavigationBarTheme(getCurrentActivity(), light);
                             WritableMap map = Arguments.createMap();

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {NativeModules, Platform} from 'react-native';
+import {NativeModules, Platform, processColor} from 'react-native';
 
 const {NavigationBarColor} = NativeModules;
 
@@ -9,7 +9,7 @@ const changeNavigationBarColor = (
 ) => {
   if (Platform.OS === 'android') {
     const LightNav = light ? true : false;
-    NavigationBarColor.changeNavigationBarColor(color, LightNav, animated);
+    return NavigationBarColor.changeNavigationBarColor(processColor(color), LightNav, animated);
   }
 };
 const hideNavigationBar = () => {
@@ -21,7 +21,7 @@ const hideNavigationBar = () => {
 };
 const showNavigationBar = () => {
   if (Platform.OS === 'android') {
-    NavigationBarColor.showNavigationBar();
+    return NavigationBarColor.showNavigationBar();
   } else {
     return false;
   }


### PR DESCRIPTION
Now colors like  `#fff`, `rgba(28,28,28)` are accepted. They are converted by react native via `processColor`.
`transparent` is correctly handled by android `@ColorInt` but `translucent` keyword isn't really supported by `processColor` but it resolve to `null` so I guess that's acceptable.

Note: I made this PR via GitHub UI, so feel free to use "Squash and Merge" button to get a clean git history.
I am using this patch locally via `patch-package` and it works great for me.